### PR TITLE
修复无法添加用户的BUG

### DIFF
--- a/App/HttpController/Api/Users.php
+++ b/App/HttpController/Api/Users.php
@@ -71,10 +71,10 @@ class Users extends Base
         ]);
 
         $data  = [
-            'u_id'            => $param['u_id'],
+            // 'u_id'            => $param['u_id'],
             'u_password'      => $param['u_password'] ?? 'e10adc3949ba59abbe56e057f20f883e',
             'u_name'          => $param['u_name'] ?? '',
-            'u_account'       => $param['u_account'],
+            'u_account'       => $param['u_account'] ?? $account,
             'p_u_id'          => $param['p_u_id'] ?? '',
             'role_id'         => $param['role_id'],
             'u_status'        => $param['u_status'] ?? '1',


### PR DESCRIPTION
account生成后没有使用，导致的小bug，使得用户无法创建。添加数据库的时候u_account是空的，u_id自增的，可加可不加